### PR TITLE
Update wakeup_dead_nodes.lua

### DIFF
--- a/wakeup_dead_nodes.lua
+++ b/wakeup_dead_nodes.lua
@@ -22,7 +22,7 @@ while true do
     
     if status >= "1" then 
       fibaro:debug(day.."/"..month..":"..i..' DEAD '..name..":"..room); 
-      fibaro:wakeUpDeadDevice(i) 
+      fibaro:call(i, "wakeUpDeadDevice") 
       fibaro:sleep(5000) --check again in 5 sec 
       status = fibaro:getValue(i, 'dead'); 
       if status >= "1" then


### PR DESCRIPTION
The syntax for waking up dead nodes was wrong. fibaro:call(i, "wakeUpDeadDevice") is working better.